### PR TITLE
Bugfix for Postman Tests Failing due to `scheduled date` field in Events table

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,10 +2,11 @@ name: Continuous Integration
 
 on:
   pull_request:
+    branches:
+      - main
+      - dev
   push:
-    branches-ignore:
-      - docs
-      - docs/**
+
 permissions:
   contents: read
 
@@ -51,3 +52,82 @@ jobs:
 
     - name: Run PHPUnit tests with coverage
       run: phpunit tests --coverage-text
+
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'pull_request' }}
+
+    services:
+      mariadb:
+        image: mariadb:latest
+        env:
+          MARIADB_ALLOW_EMPTY_PASSWORD: "yes"
+          MARIADB_DATABASE: f1_db
+          MARIADB_USER: root
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+        ports:
+          - 3306:3306
+        volumes:
+          - ${{ github.workspace }}:/docker-entrypoint-initdb.d
+        # The volumes line will automatically import any .sql files from this directory into the MariaDB container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore Composer packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mysqli, pdo_mysql
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Import f1_db.sql into MariaDB
+        run: |
+          echo "Importing f1_db.sql..."
+          mysql -h 127.0.0.1 -u root < f1_db.sql
+
+      - name: Start PHP server
+        run: php -S 127.0.0.1:8080 -t public > php_server.log 2>&1 &
+        working-directory: ./ # Path to the public folder from the project root
+
+      - name: Cache node_modules for Newman
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Newman
+        run: npm install -g newman
+
+      - name: Run Postman tests
+        run: newman run "./postman/collections/F1 Management API.json" --env-var baseUrl=http://127.0.0.1:8080
+
+      - name: Display PHP server logs
+        if: always()
+        run: cat php_server.log
+
+      - name: Shutdown PHP server
+        if: always()
+        run: killall php

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,13 +6,11 @@ on:
       - main
       - dev
   push:
+    branches-ignore:
+      - '**'
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,48 +10,52 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id}}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build"
     runs-on: ubuntu-24.04
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate --strict
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v4
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
 
-    - name: Install dependencies with Composer
-      run: composer install --prefer-dist --no-progress
+      - name: Install dependencies with Composer
+        run: composer install --prefer-dist --no-progress
 
-    - name: Install PHP with extensions
-      uses: shivammathur/setup-php@2.31.1
-      with:
-        php-version: '8.2'
-        tools: phpstan, cs2pr, php-cs-fixer, phpunit
-        coverage: xdebug
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@2.31.1
+        with:
+          php-version: '8.2'
+          tools: phpstan, cs2pr, php-cs-fixer, phpunit
+          coverage: xdebug
 
-    - name: Code Quality (PHPStan)
-      run: phpstan analyse
+      - name: Code Quality (PHPStan)
+        run: phpstan analyse
 
-    - name: Code Standards (PER-CS2.0)
-      run: php-cs-fixer check src --rules=@PER-CS2.0 --format=checkstyle | cs2pr
+      - name: Code Standards (PER-CS2.0)
+        run: php-cs-fixer check src --rules=@PER-CS2.0 --format=checkstyle | cs2pr
 
-    - name: Setup problem matchers for PHPUnit
-      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-    - name: Run PHPUnit tests with coverage
-      run: phpunit tests --coverage-text
+      - name: Run PHPUnit tests with coverage
+        run: phpunit tests --coverage-text
 
   test:
     name: "Test"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.idea/I425-Team-Project.iml
+++ b/.idea/I425-Team-Project.iml
@@ -76,6 +76,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php83" />
       <excludeFolder url="file://$MODULE_DIR$/.github" />
       <excludeFolder url="file://$MODULE_DIR$/.postman" />
+      <excludeFolder url="file://$MODULE_DIR$/postman" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/f1_db.sql
+++ b/f1_db.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: 127.0.0.1
--- Generation Time: Oct 18, 2024 at 01:37 AM
+-- Generation Time: Oct 24, 2024 at 02:27 AM
 -- Server version: 10.4.32-MariaDB
 -- PHP Version: 8.2.12
 
@@ -320,7 +320,7 @@ INSERT INTO `drivers` (`id`, `first_name`, `last_name`, `team_id`, `nationality_
 CREATE TABLE `events` (
   `id` smallint(5) UNSIGNED NOT NULL,
   `title` varchar(100) NOT NULL,
-  `scheduled_date` timestamp NULL DEFAULT NULL,
+  `scheduled_date` date DEFAULT NULL,
   `track_id` smallint(5) UNSIGNED DEFAULT NULL,
   `status` enum('Planned','Ongoing','Completed','Cancelled') NOT NULL DEFAULT 'Planned'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
@@ -329,22 +329,51 @@ CREATE TABLE `events` (
 -- Dumping data for table `events`
 --
 
-INSERT INTO `events` (`id`, `title`, `scheduled_date`, `track_id`, `status`) VALUES
-(1, 'Formula 1 Grand Prix de Monaco 2024', '2024-05-26 18:00:00', 1, 'Completed'),
-(2, 'Formula 1 Aramco British Grand Prix 2024', '2024-07-07 18:00:00', 2, 'Completed'),
-(3, 'Formula 1 Pirelli Gran Premio D\'Italia 2024', '2024-09-08 18:00:00', 3, 'Completed'),
-(4, 'Formula 1 Rolex Belgian Grand Prix 2024', '2024-08-25 18:00:00', 4, 'Completed'),
-(5, 'Formula 1 Honda Japanese Grand Prix 2024', '2024-10-13 18:00:00', 5, 'Completed'),
-(6, 'Formula 1 Pirelli Grand Prix du Canada 2024', '2024-06-09 18:00:00', 6, 'Completed'),
-(7, 'Formula 1 Singapore Airlines Singapore Grand Prix 2024', '2024-09-22 18:00:00', 7, 'Completed'),
-(8, 'Formula 1 Heineken Grande Prêmio de São Paulo 2024', '2024-11-17 19:00:00', 8, 'Planned'),
-(9, 'Formula 1 Lenovo United States Grand Prix 2024', '2024-10-20 18:00:00', 9, 'Planned'),
-(10, 'Formula 1 Etihad Airways Abu Dhabi Grand Prix 2024', '2024-12-01 19:00:00', 10, 'Planned'),
-(11, 'Formula 1 Rolex Australian Grand Prix 2024', '2024-03-17 18:00:00', 11, 'Completed'),
-(12, 'Formula 1 STC Saudi Arabian Grand Prix 2024', '2024-03-31 18:00:00', 12, 'Completed'),
-(13, 'Formula 1 Rolex Großer Preis von Österreich 2024', '2024-07-14 18:00:00', 13, 'Completed'),
-(14, 'Formula 1 Gulf Air Bahrain Grand Prix 2024', '2024-03-03 19:00:00', 14, 'Completed'),
-(15, 'Formula 1 Qatar Airways Hungarian Grand Prix 2024', '2024-08-04 18:00:00', 15, 'Completed');
+INSERT INTO `events` (`id`, `title`, `scheduled_date`, `track_id`, `status`) VALUES (1,
+                                                                                     'Formula 1 Grand Prix de Monaco 2024',
+                                                                                     '2024-05-26', 1, 'Completed'),
+                                                                                    (2,
+                                                                                     'Formula 1 Aramco British Grand Prix 2024',
+                                                                                     '2024-07-07', 2, 'Completed'),
+                                                                                    (3,
+                                                                                     'Formula 1 Pirelli Gran Premio D\'Italia 2024',
+                                                                                     '2024-09-08', 3, 'Completed'),
+                                                                                    (4,
+                                                                                     'Formula 1 Rolex Belgian Grand Prix 2024',
+                                                                                     '2024-08-25', 4, 'Completed'),
+                                                                                    (5,
+                                                                                     'Formula 1 Honda Japanese Grand Prix 2024',
+                                                                                     '2024-10-13', 5, 'Completed'),
+                                                                                    (6,
+                                                                                     'Formula 1 Pirelli Grand Prix du Canada 2024',
+                                                                                     '2024-06-09', 6, 'Completed'),
+                                                                                    (7,
+                                                                                     'Formula 1 Singapore Airlines Singapore Grand Prix 2024',
+                                                                                     '2024-09-22', 7, 'Completed'),
+                                                                                    (8,
+                                                                                     'Formula 1 Heineken Grande Prêmio de São Paulo 2024',
+                                                                                     '2024-11-17', 8, 'Planned'),
+                                                                                    (9,
+                                                                                     'Formula 1 Lenovo United States Grand Prix 2024',
+                                                                                     '2024-10-20', 9, 'Planned'),
+                                                                                    (10,
+                                                                                     'Formula 1 Etihad Airways Abu Dhabi Grand Prix 2024',
+                                                                                     '2024-12-01', 10, 'Planned'),
+                                                                                    (11,
+                                                                                     'Formula 1 Rolex Australian Grand Prix 2024',
+                                                                                     '2024-03-17', 11, 'Completed'),
+                                                                                    (12,
+                                                                                     'Formula 1 STC Saudi Arabian Grand Prix 2024',
+                                                                                     '2024-03-31', 12, 'Completed'),
+                                                                                    (13,
+                                                                                     'Formula 1 Rolex Großer Preis von Österreich 2024',
+                                                                                     '2024-07-14', 13, 'Completed'),
+                                                                                    (14,
+                                                                                     'Formula 1 Gulf Air Bahrain Grand Prix 2024',
+                                                                                     '2024-03-03', 14, 'Completed'),
+                                                                                    (15,
+                                                                                     'Formula 1 Qatar Airways Hungarian Grand Prix 2024',
+                                                                                     '2024-08-04', 15, 'Completed');
 
 -- --------------------------------------------------------
 

--- a/postman/collections/F1 Management API.json
+++ b/postman/collections/F1 Management API.json
@@ -2374,7 +2374,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"title\": \"New Event\",\n  \"scheduled_date\": \"2024-05-26T18:00:00Z\",\n  \"track_id\": 1,\n  \"status\": \"Planned\"\n}",
+							"raw": "{\n  \"title\": \"New Event\",\n  \"scheduled_date\": \"2024-05-26\",\n  \"track_id\": 1,\n  \"status\": \"Planned\"\n}",
 							"options": {
 								"raw": {
 									"headerFamily": "json",
@@ -2797,7 +2797,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"title\": \"Updated Event\",\n  \"scheduled_date\": \"2024-05-26T18:00:00Z\",\n  \"track_id\": 2,\n  \"status\": \"Cancelled\"\n}",
+							"raw": "{\n  \"title\": \"Updated Event\",\n  \"scheduled_date\": \"2024-05-26\",\n  \"track_id\": 2,\n  \"status\": \"Cancelled\"\n}",
 							"options": {
 								"raw": {
 									"headerFamily": "json",

--- a/src/Models/Event.php
+++ b/src/Models/Event.php
@@ -22,6 +22,13 @@ class Event extends Model
     protected $fillable = ['title', 'scheduled_date', 'track_id', 'status'];
 
     /**
+     * @var string[]
+     */
+    protected $casts = [
+        'scheduled_date' => 'date:Y-m-d',
+    ];
+
+    /**
      * @return BelongsTo<Track, $this>
      */
     public function track(): BelongsTo


### PR DESCRIPTION
This pull request includes significant updates to the continuous integration workflow, database schema, and related files. The most important changes involve modifying the CI configuration to include a new test job, updating the database schema for the `events` table, and ensuring consistency in date formats across different files.

Continuous Integration updates:

* [`.github/workflows/continuous-integration.yml`](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434R5-R11): Added branches `main` and `dev` to the `pull_request` trigger, ignored all branches for `push` events, and added a new `test` job with MariaDB service and steps to run PHPUnit and Postman tests. [[1]](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434R5-R11) [[2]](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434R57-R135)

Database schema updates:

* [`f1_db.sql`](diffhunk://#diff-5c8d781be414941379dae90f1fba8a6bc80ec101f8f949d3d7b72f5daed18a0cL323-R323): Changed the `scheduled_date` column in the `events` table from `timestamp` to `date`, and reformatted the `INSERT INTO events` statements to use the new date format. [[1]](diffhunk://#diff-5c8d781be414941379dae90f1fba8a6bc80ec101f8f949d3d7b72f5daed18a0cL323-R323) [[2]](diffhunk://#diff-5c8d781be414941379dae90f1fba8a6bc80ec101f8f949d3d7b72f5daed18a0cL332-R376)

Postman collection updates:

* [`postman/collections/F1 Management API.json`](diffhunk://#diff-8281a9afdf0c2b6a1240e638aceca3f6b2de0255a586b7105d0e6b3232812f1eL2377-R2377): Updated the `scheduled_date` fields in the raw body of the requests to use the new date format without time. [[1]](diffhunk://#diff-8281a9afdf0c2b6a1240e638aceca3f6b2de0255a586b7105d0e6b3232812f1eL2377-R2377) [[2]](diffhunk://#diff-8281a9afdf0c2b6a1240e638aceca3f6b2de0255a586b7105d0e6b3232812f1eL2800-R2800)

Model updates:

* [`src/Models/Event.php`](diffhunk://#diff-6db5d1cc9ca207aa3563e6817c791cf0aac101ee37006902f1d3a46180b8db49R24-R30): Added a cast to format the `scheduled_date` attribute as `Y-m-d`.

IDE configuration updates:

* [`.idea/I425-Team-Project.iml`](diffhunk://#diff-9c50cd815e367e054d713270601df7fee6957c2ea2efcebc106e0545a8e66c46R79): Added the `postman` folder to the list of excluded folders.