### PR TITLE
Add OpenAPI Linting to Development Pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,6 +33,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-php-
 
+      - name: Cache node_modules for Redocly CLI
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install/Restore Redocly CLI
+        run: npm i -g @redocly/cli@latest
+
       - name: Install dependencies with Composer
         run: composer install --prefer-dist --no-progress --no-suggest --no-interaction --optimize-autoloader
 
@@ -44,10 +56,13 @@ jobs:
           coverage: xdebug
 
       - name: Code Quality (PHPStan)
-        run: phpstan analyse
+        run: phpstan analyze --error-format=checkstyle | cs2pr --colorize
 
       - name: Code Standards (PER-CS2.0)
-        run: php-cs-fixer check --format=checkstyle | cs2pr
+        run: php-cs-fixer check --format=checkstyle | cs2pr --colorize
+
+      - name: OpenAPI Standards
+        run: redocly lint docs/openapi.yaml --format=checkstyle | cs2pr --colorize
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,97 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redocly.com/docs/cli/ for more information.
+docs/openapi.yaml:
+  info-license:
+    - '#/info'
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/paths/cars.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/post/operationId'
+  operation-4xx-response:
+    - '#/get/responses'
+  security-defined:
+    - '#/get'
+    - '#/post'
+docs/paths/cars/{id}.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/delete/operationId'
+    - '#/patch/operationId'
+  security-defined:
+    - '#/get'
+    - '#/delete'
+    - '#/patch'
+docs/paths/drivers.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/post/operationId'
+  operation-4xx-response:
+    - '#/get/responses'
+  security-defined:
+    - '#/get'
+    - '#/post'
+docs/paths/drivers/{id}.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/delete/operationId'
+    - '#/patch/operationId'
+  security-defined:
+    - '#/get'
+    - '#/delete'
+    - '#/patch'
+docs/paths/events.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/post/operationId'
+  operation-4xx-response:
+    - '#/get/responses'
+  security-defined:
+    - '#/get'
+    - '#/post'
+docs/paths/events/{id}.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/delete/operationId'
+    - '#/patch/operationId'
+  security-defined:
+    - '#/get'
+    - '#/delete'
+    - '#/patch'
+docs/paths/teams.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/post/operationId'
+  operation-4xx-response:
+    - '#/get/responses'
+  security-defined:
+    - '#/get'
+    - '#/post'
+docs/paths/teams/{id}.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/delete/operationId'
+    - '#/patch/operationId'
+  security-defined:
+    - '#/get'
+    - '#/delete'
+    - '#/patch'
+docs/paths/tracks.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/post/operationId'
+  operation-4xx-response:
+    - '#/get/responses'
+  security-defined:
+    - '#/get'
+    - '#/post'
+docs/paths/tracks/{id}.yaml:
+  operation-operationId:
+    - '#/get/operationId'
+    - '#/delete/operationId'
+    - '#/patch/operationId'
+  security-defined:
+    - '#/get'
+    - '#/delete'
+    - '#/patch'


### PR DESCRIPTION
This pull request introduces several improvements to the continuous integration workflow, particularly by integrating Redocly CLI for OpenAPI standards and enhancing code quality checks. Additionally, a new configuration file for Redocly's linter is added to manage API documentation rules.

### Continuous Integration Enhancements:
* Added caching for `node_modules` to speed up Redocly CLI installations (`.github/workflows/continuous-integration.yml`).
* Integrated Redocly CLI installation and OpenAPI standards check into the CI workflow (`.github/workflows/continuous-integration.yml`) [[1]](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434R36-R47) [[2]](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434L47-R65).
* Updated PHPStan and PHP-CS-Fixer commands to include colorized output for better readability (`.github/workflows/continuous-integration.yml`).

### Linter Configuration:
* Added `.redocly.lint-ignore.yaml` to specify rules for Redocly's linter to ignore certain parts of the API documentation (`.redocly.lint-ignore.yaml`).